### PR TITLE
Fix for glyph with no unicode attribute

### DIFF
--- a/src/EasySVG.php
+++ b/src/EasySVG.php
@@ -146,19 +146,19 @@ class EasySVG {
                     $unicode = $this->_utf8ToUnicode($unicode);
                     
                     if (isset($unicode[0])) {
-	                    $unicode = $unicode[0];
-	
-	                    $this->font->glyphs[$unicode] = new stdClass();
-	                    $this->font->glyphs[$unicode]->horizAdvX = $z->getAttribute('horiz-adv-x');
-	                    if (empty($this->font->glyphs[$unicode]->horizAdvX)) {
-	                        $this->font->glyphs[$unicode]->horizAdvX = $this->font->horizAdvX;
-	                    }
-	                    $this->font->glyphs[$unicode]->d = $z->getAttribute('d');
-	
-	                    // save em value for letter spacing (109 is unicode for the letter 'm')
-	                    if ($unicode == '109') {
-	                        $this->font->em = $this->font->glyphs[$unicode]->horizAdvX;
-	                    }
+                        $unicode = $unicode[0];
+    
+                        $this->font->glyphs[$unicode] = new stdClass();
+                        $this->font->glyphs[$unicode]->horizAdvX = $z->getAttribute('horiz-adv-x');
+                        if (empty($this->font->glyphs[$unicode]->horizAdvX)) {
+                            $this->font->glyphs[$unicode]->horizAdvX = $this->font->horizAdvX;
+                        }
+                        $this->font->glyphs[$unicode]->d = $z->getAttribute('d');
+    
+                        // save em value for letter spacing (109 is unicode for the letter 'm')
+                        if ($unicode == '109') {
+                            $this->font->em = $this->font->glyphs[$unicode]->horizAdvX;
+                        }
                     }
                 }
             }

--- a/src/EasySVG.php
+++ b/src/EasySVG.php
@@ -144,18 +144,21 @@ class EasySVG {
                 if ($name == 'glyph') {
                     $unicode = $z->getAttribute('unicode');
                     $unicode = $this->_utf8ToUnicode($unicode);
-                    $unicode = $unicode[0];
-
-                    $this->font->glyphs[$unicode] = new stdClass();
-                    $this->font->glyphs[$unicode]->horizAdvX = $z->getAttribute('horiz-adv-x');
-                    if (empty($this->font->glyphs[$unicode]->horizAdvX)) {
-                        $this->font->glyphs[$unicode]->horizAdvX = $this->font->horizAdvX;
-                    }
-                    $this->font->glyphs[$unicode]->d = $z->getAttribute('d');
-
-                    // save em value for letter spacing (109 is unicode for the letter 'm')
-                    if ($unicode == '109') {
-                        $this->font->em = $this->font->glyphs[$unicode]->horizAdvX;
+                    
+                    if (isset($unicode[0])) {
+	                    $unicode = $unicode[0];
+	
+	                    $this->font->glyphs[$unicode] = new stdClass();
+	                    $this->font->glyphs[$unicode]->horizAdvX = $z->getAttribute('horiz-adv-x');
+	                    if (empty($this->font->glyphs[$unicode]->horizAdvX)) {
+	                        $this->font->glyphs[$unicode]->horizAdvX = $this->font->horizAdvX;
+	                    }
+	                    $this->font->glyphs[$unicode]->d = $z->getAttribute('d');
+	
+	                    // save em value for letter spacing (109 is unicode for the letter 'm')
+	                    if ($unicode == '109') {
+	                        $this->font->em = $this->font->glyphs[$unicode]->horizAdvX;
+	                    }
                     }
                 }
             }


### PR DESCRIPTION
Thanks for creating this project. When I was using it today I came across an error/notice when using a font with a glyph without the `unicode` attribute:

`Notice: Undefined offset: 0 in EasySVG.php on line 147`

This PR fixes that notice.
