### PR TITLE
make font color optional

### DIFF
--- a/src/EasySVG.php
+++ b/src/EasySVG.php
@@ -23,7 +23,7 @@ class EasySVG {
         $this->font->descent = 0;
         $this->font->glyphs = array();
         $this->font->size = 20;
-        $this->font->color = '#000000';
+        $this->font->color = '';
         $this->font->lineHeight = 1;
         $this->font->letterSpacing = 0;
 
@@ -195,7 +195,9 @@ class EasySVG {
             $def = $this->defTranslate($def, $x, $y);
         }
 
-        $attributes['fill'] = $this->font->color;
+        if($this->font->color) {
+            $attributes['fill'] = $this->font->color;
+        }
 
         return $this->addPath($def, $attributes);
     }


### PR DESCRIPTION
When no fill color is given, browsers will default to black. It is also not needed to set the color when it is set by CSS later anyway.