### PR TITLE
Update this library to a supported PHP version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[composer.json]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-.DS_Store
 vendor/
+.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+$finder = PhpCsFixer\Finder::create()
+    ->in('src');
+
+$config = new PhpCsFixer\Config();
+return $config->setRules([
+    '@PSR12' => true,
+    'array_syntax' => ['syntax' => 'short'],
+])
+    ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,8 @@
   },
   "minimum-stability": "beta",
   "require": {
-    "php": ">=5.3.0"
+    "php": ">=7.4.0",
+    "ext-simplexml": "*",
+    "ext-xmlreader": "*"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "kartsims/easysvg",
   "description": "PHP library to generate SVG XML",
   "license": "MIT",
-  "homepage": "http://kartsims.github.com/easysvg/",
+  "homepage": "https://github.com/kartsims/easysvg",
   "authors": [
     {
       "name": "Simon Tarchichi",
@@ -21,5 +21,8 @@
     "php": ">=7.4.0",
     "ext-simplexml": "*",
     "ext-xmlreader": "*"
+  },
+  "require-dev": {
+    "friendsofphp/php-cs-fixer": "^3.5"
   }
 }

--- a/src/EasySVG.php
+++ b/src/EasySVG.php
@@ -10,8 +10,8 @@
  */
 class EasySVG {
 
-    protected $font;
-    protected $svg;
+    protected stdClass $font;
+    protected SimpleXMLElement $svg;
 
     public function __construct() {
         // default font data
@@ -32,7 +32,8 @@ class EasySVG {
         $this->clearSVG();
     }
 
-    public function clearSVG() {
+    public function clearSVG(): void
+    {
         $this->svg = new SimpleXMLElement('<svg></svg>');
         $this->svg->addAttribute('version', '1.1');
         $this->svg->addAttribute('xmlns', 'http://www.w3.org/2000/svg');
@@ -40,27 +41,31 @@ class EasySVG {
 
     /**
      * Function takes UTF-8 encoded string and returns unicode number for every character.
-     * @param  string $str
-     * @return string
+     * @param string $str
+     * @return array
      */
-    private function _utf8ToUnicode( $str ) {
-        $unicode = array();
-        $values = array();
+    private function _utf8ToUnicode( string $str ): array
+    {
+        $unicode = [];
+        $values = [];
         $lookingFor = 1;
 
-        for ($i = 0; $i < strlen( $str ); $i++ ) {
+        for ($i = 0, $iMax = strlen($str); $i < $iMax; $i++ ) {
             $thisValue = ord( $str[ $i ] );
-            if ( $thisValue < 128 ) $unicode[] = $thisValue;
-            else {
-                if ( count( $values ) == 0 ) $lookingFor = ( $thisValue < 224 ) ? 2 : 3;
+            if ( $thisValue < 128 ) {
+                $unicode[] = $thisValue;
+            } else {
+                if ( count( $values ) === 0 ) {
+                    $lookingFor = ($thisValue < 224) ? 2 : 3;
+                }
                 $values[] = $thisValue;
-                if ( count( $values ) == $lookingFor ) {
-                    $number = ( $lookingFor == 3 ) ?
+                if ( count( $values ) === $lookingFor ) {
+                    $number = ( $lookingFor === 3 ) ?
                         ( ( $values[0] % 16 ) * 4096 ) + ( ( $values[1] % 64 ) * 64 ) + ( $values[2] % 64 ):
                         ( ( $values[0] % 32 ) * 64 ) + ( $values[1] % 64 );
 
                     $unicode[] = $number;
-                    $values = array();
+                    $values = [];
                     $lookingFor = 1;
                 }
             }
@@ -73,9 +78,10 @@ class EasySVG {
      * Set font params (short-hand method)
      * @param string $filepath
      * @param integer $size
-     * @param string $color
+     * @param string|null $color
      */
-    public function setFont( $filepath, $size, $color = null ) {
+    public function setFont( string $filepath, int $size, string $color = null ): void
+    {
         $this->setFontSVG($filepath);
         $this->setFontSize($size);
         if ($color) {
@@ -88,7 +94,8 @@ class EasySVG {
      * @param int $size
      * @return void
      */
-    public function setFontSize( $size ) {
+    public function setFontSize( int $size ): void
+    {
         $this->font->size = $size;
     }
 
@@ -97,7 +104,8 @@ class EasySVG {
      * @param bool $bool
      * @return void
      */
-    public function setUseKerning( $bool ) {
+    public function setUseKerning( bool $bool ): void
+    {
         $this->font->useKerning = $bool;
     }
 
@@ -106,25 +114,28 @@ class EasySVG {
      * @param string $color
      * @return void
      */
-    public function setFontColor( $color ) {
+    public function setFontColor( string $color ): void
+    {
         $this->font->color = $color;
     }
 
     /**
      * Set the line height from default (1) to custom value
-     * @param  float $value
+     * @param float $value
      * @return void
      */
-    public function setLineHeight( $value ) {
+    public function setLineHeight( float $value ): void
+    {
         $this->font->lineHeight = $value;
     }
 
     /**
      * Set the letter spacing from default (0) to custom value
-     * @param  float $value
+     * @param float $value
      * @return void
      */
-    public function setLetterSpacing( $value ) {
+    public function setLetterSpacing( float $value ): void
+    {
         $this->font->letterSpacing = $value;
     }
 
@@ -132,11 +143,12 @@ class EasySVG {
      * Function takes path to SVG font (local path) and processes its xml
      * to get path representation of every character and additional
      * font parameters
-     * @param  string $filepath
+     * @param string $filepath
      * @return void
      */
-    public function setFontSVG( $filepath ) {
-        $this->font->glyphs = array();
+    public function setFontSVG( string $filepath ): void
+    {
+        $this->font->glyphs = [];
         $z = new XMLReader;
         $z->open($filepath);
 
@@ -144,19 +156,19 @@ class EasySVG {
         while ($z->read()) {
             $name = $z->name;
 
-            if ($z->nodeType == XMLReader::ELEMENT) {
-                if ($name == 'font') {
+            if ($z->nodeType === XMLReader::ELEMENT) {
+                if ($name === 'font') {
                     $this->font->id = $z->getAttribute('id');
                     $this->font->horizAdvX = $z->getAttribute('horiz-adv-x');
                 }
 
-                if ($name == 'font-face') {
+                if ($name === 'font-face') {
                     $this->font->unitsPerEm = $z->getAttribute('units-per-em');
                     $this->font->ascent = $z->getAttribute('ascent');
                     $this->font->descent = $z->getAttribute('descent');
                 }
 
-                if ($name == 'glyph') {
+                if ($name === 'glyph') {
                     $unicode = $z->getAttribute('unicode');
                     $unicode = $this->_utf8ToUnicode($unicode);
 
@@ -171,20 +183,20 @@ class EasySVG {
                         $this->font->glyphs[$unicode]->d = $z->getAttribute('d');
 
                         // save em value for letter spacing (109 is unicode for the letter 'm')
-                        if ($unicode == '109') {
+                        if ($unicode === '109') {
                             $this->font->em = $this->font->glyphs[$unicode]->horizAdvX;
                         }
                     }
                 }
-                if ($name == 'hkern') {
+
+                if ($name === 'hkern') {
                     $u1 = $this->_utf8ToUnicode($z->getAttribute('u1'));
                     $u2 = $this->_utf8ToUnicode($z->getAttribute('u2'));
-                    if (isset($u1[0]) and isset ($u2[0])) {
+                    if (isset($u1[0], $u2[0])) {
                         $k = $z->getAttribute('k');
                         $this->font->hkern[$u1[0]][$u2[0]] = $k;
                     }
                 }
-
             }
         }
     }
@@ -193,30 +205,38 @@ class EasySVG {
      * Add a path to the SVG
      * @param string $def
      * @param array $attributes
-     * @return SimpleXMLElement
+     * @return null|SimpleXMLElement
      */
-    public function addPath($def, $attributes=array()) {
+    public function addPath(string $def, array $attributes=array()): ?SimpleXMLElement
+    {
         $path = $this->svg->addChild('path');
-        foreach($attributes as $key=>$value){
+        if ($path === null) {
+            return null;
+        }
+
+        foreach($attributes as $key => $value) {
             $path->addAttribute($key, $value);
         }
+
         $path->addAttribute('d', $def);
+
         return $path;
     }
 
     /**
      * Add a text to the SVG
-     * @param string $def
-     * @param float/string $x
-     * @param float/string $y
+     * @param string $text
+     * @param float|string $x
+     * @param float|string $y
      * @param array $attributes
-     * @return SimpleXMLElement
+     * @return null|SimpleXMLElement
      */
-    public function addText($text, $x=0, $y=0, $attributes=array()) {
+    public function addText(string $text, $x = 0, $y = 0, array $attributes=array()): ?SimpleXMLElement
+    {
         $def = $this->textDef($text);
 
         if ($x === 'center' || $y === 'center') {
-            list($textWidth, $textHeight) = $this->textDimensions($text);
+            [$textWidth, $textHeight] = $this->textDimensions($text);
         }
 
         // center horizontally
@@ -224,7 +244,7 @@ class EasySVG {
             if ($this->svg['width'] === NULL) {
                 throw new Error('SVG width has to be set to center the text horizontally');
             }
-            $x = (intval($this->svg['width']) - $textWidth) / 2;
+            $x = ((int)$this->svg['width'] - $textWidth) / 2;
         }
 
         // center vertically
@@ -232,10 +252,10 @@ class EasySVG {
             if ($this->svg['height'] === NULL) {
                 throw new Error('SVG height has to be set to center the text vertically');
             }
-            $y = (intval($this->svg['height']) - $textHeight) / 2;
+            $y = ((int)$this->svg['height'] - $textHeight) / 2;
         }
 
-        if($x!=0 || $y!=0){
+        if($x !== 0 || $y !== 0){
             $def = $this->defTranslate($def, $x, $y);
         }
 
@@ -246,31 +266,26 @@ class EasySVG {
         return $this->addPath($def, $attributes);
     }
 
-
     /**
      * Function takes UTF-8 encoded string and size, returns xml for SVG paths representing this string.
      * @param string $text UTF-8 encoded text
      * @return string xml for text converted into SVG paths
      */
-    public function textDef($text) {
+    public function textDef(string $text): string
+    {
         $def = array();
 
         $horizAdvX = 0;
         $horizAdvY = $this->font->ascent + $this->font->descent;
-        $fontSize = floatval($this->font->size) / $this->font->unitsPerEm;
-        $text = $this->_utf8ToUnicode($text);
+        $fontSize = (float)$this->font->size / $this->font->unitsPerEm;
+        $textUnicode = $this->_utf8ToUnicode($text);
 
         $prevLetter = '';
 
-        for($i = 0; $i < count($text); $i++) {
-
-            $letter = $text[$i];
-
+        foreach ($textUnicode as $letter) {
             // kern
-            if ($this->font->useKerning) {
-                if (isset ($this->font->hkern[$prevLetter][$letter])) {
-                    $horizAdvX -= $this->font->hkern[$prevLetter][$letter] * $fontSize;
-                }
+            if ($this->font->useKerning && isset ($this->font->hkern[$prevLetter][$letter])) {
+                $horizAdvX -= $this->font->hkern[$prevLetter][$letter] * $fontSize;
             }
 
             //ignore this glyph instead of throwing an error if the font does not define it
@@ -279,7 +294,7 @@ class EasySVG {
             }
 
             // line break support (10 is unicode for linebreak)
-            if($letter==10){
+            if($letter === 10){
                 $horizAdvX = 0;
                 $horizAdvY += $this->font->lineHeight * ( $this->font->ascent + $this->font->descent );
                 continue;
@@ -306,13 +321,12 @@ class EasySVG {
     /**
      * Function takes UTF-8 encoded string and size, returns width and height of the whole text
      * @param string $text UTF-8 encoded text
-     * @return array ($width, $height)
+     * @return array{width: float, height: float}
      */
-    public function textDimensions($text) {
-        $def = array();
-
-        $fontSize = floatval($this->font->size) / $this->font->unitsPerEm;
-        $text = $this->_utf8ToUnicode($text);
+    public function textDimensions(string $text): array
+    {
+        $fontSize = (float)$this->font->size / $this->font->unitsPerEm;
+        $textUnicode = $this->_utf8ToUnicode($text);
 
         $lineWidth = 0;
         $lineHeight = ( $this->font->ascent + $this->font->descent ) * $fontSize * 2;
@@ -322,18 +336,15 @@ class EasySVG {
 
         $prevLetter = '';
 
-        for($i = 0; $i < count($text); $i++) {
-
-            $letter = $text[$i];
-
+        foreach ($textUnicode as $letter) {
             //ignore this glyph instead of throwing an error if the font does not define it
             if(!array_key_exists($letter, $this->font->glyphs)){
                 continue;
             }
 
             // line break support (10 is unicode for linebreak)
-            if($letter==10){
-                $width = $lineWidth>$width ? $lineWidth : $width;
+            if($letter === 10){
+                $width = max($lineWidth, $width);
                 $height += $lineHeight * $this->font->lineHeight;
                 $lineWidth = 0;
                 continue;
@@ -342,17 +353,15 @@ class EasySVG {
             $lineWidth += $this->font->glyphs[$letter]->horizAdvX * $fontSize + $this->font->em * $this->font->letterSpacing * $fontSize;
 
             // kern
-            if ($this->font->useKerning) {
-                if (isset ($this->font->hkern[$prevLetter][$letter])) {
-                    $lineWidth -= $this->font->hkern[$prevLetter][$letter] * $fontSize;
-                }
+            if ($this->font->useKerning && isset ($this->font->hkern[$prevLetter][$letter])) {
+                $lineWidth -= $this->font->hkern[$prevLetter][$letter] * $fontSize;
             }
 
             $prevLetter = $letter;
         }
 
         // only keep the widest line's width
-        $width = $lineWidth>$width ? $lineWidth : $width;
+        $width = max($lineWidth, $width);
 
         return array($width, $height);
     }
@@ -360,31 +369,30 @@ class EasySVG {
 
     /**
      * Function takes unicode character and returns the UTF-8 equivalent
-     * @param  string $str
+     * @param string $unicode
      * @return string
      */
-    public function unicodeDef( $unicode ) {
+    public function unicodeDef( string $unicode ): string
+    {
 
         $horizAdvY = $this->font->ascent + $this->font->descent;
-        $fontSize =  floatval($this->font->size) / $this->font->unitsPerEm;
+        $fontSize =  (float)$this->font->size / $this->font->unitsPerEm;
 
         // extract character definition
         $d = $this->font->glyphs[hexdec($unicode)]->d;
 
         // transform typo from original SVG format to straight display
         $d = $this->defScale($d, $fontSize, -$fontSize);
-        $d = $this->defTranslate($d, 0, $horizAdvY*$fontSize*2);
-
-        return $d;
+        return $this->defTranslate($d, 0, $horizAdvY*$fontSize*2);
     }
 
     /**
      * Returns the character width, as set in the font file
-     * @param  string  $str
-     * @param  boolean $is_unicode
+     * @param string $char
+     * @param boolean $is_unicode
      * @return float
      */
-    public function characterWidth( $char, $is_unicode = false ) {
+    public function characterWidth( string $char, bool $is_unicode = false ) {
         if ($is_unicode){
             $letter = hexdec($char);
         }
@@ -395,68 +403,71 @@ class EasySVG {
         if (!isset($this->font->glyphs[$letter]))
             return NULL;
 
-        $fontSize = floatval($this->font->size) / $this->font->unitsPerEm;
+        $fontSize = (float)$this->font->size / $this->font->unitsPerEm;
         return $this->font->glyphs[$letter]->horizAdvX * $fontSize;
     }
 
 
     /**
      * Applies a translate transformation to definition
-     * @param  string  $def definition
+     * @param string $def definition
      * @param  float $x
      * @param  float $y
      * @return string
      */
-    public function defTranslate($def, $x=0, $y=0){
+    public function defTranslate(string $def, float $x = 0, float $y = 0): string
+    {
         return $this->defApplyMatrix($def, array(1, 0, 0, 1, $x, $y));
     }
 
     /**
      * Applies a translate transformation to definition
-     * @param  string  $def    Definition
-     * @param  integer $angle  Rotation angle (degrees)
-     * @param  integer $x      X coordinate of rotation center
-     * @param  integer $y      Y coordinate of rotation center
+     * @param string $def    Definition
+     * @param float $angle  Rotation angle (degrees)
+     * @param float $x      X coordinate of rotation center
+     * @param float $y      Y coordinate of rotation center
      * @return string
      */
-    public function defRotate($def, $angle, $x=0, $y=0){
-        if($x==0 && $y==0){
+    public function defRotate(string $def, float $angle, float $x = 0, float $y = 0): string
+    {
+        if($x === 0 && $y === 0){
             $angle = deg2rad($angle);
-            return $this->defApplyMatrix($def, array(cos($angle), sin($angle), -sin($angle), cos($angle), 0, 0));
+            return $this->defApplyMatrix($def, [cos($angle), sin($angle), -sin($angle), cos($angle), 0, 0]);
         }
 
         // rotate by a given point
         $def = $this->defTranslate($def, $x, $y);
         $def = $this->defRotate($def, $angle);
-        $def = $this->defTranslate($def, -$x, -$y);
-        return $def;
+        return $this->defTranslate($def, -$x, -$y);
     }
 
     /**
      * Applies a scale transformation to definition
-     * @param  string  $def definition
-     * @param  integer $x
-     * @param  integer $y
+     * @param string $def definition
+     * @param float $x
+     * @param float $y
      * @return string
      */
-    public function defScale($def, $x=1, $y=1){
-        return $this->defApplyMatrix($def, array($x, 0, 0, $y, 0, 0));
+    public function defScale(string $def, float $x = 1, float $y = 1): string
+    {
+        return $this->defApplyMatrix($def, [$x, 0, 0, $y, 0, 0]);
     }
 
     /**
      * Calculates the new definition with the matrix applied
-     * @param  string $def
-     * @param  array  $matrix
+     * @param string $def
+     * @param array $matrix
      * @return string
      */
-    public function defApplyMatrix($def, $matrix){
-
+    public function defApplyMatrix(string $def, array $matrix): string
+    {
         // if there are several shapes in this definition, do the operation for each
         preg_match_all('/M[^zZ]*[zZ]/', $def, $shapes);
         $shapes = $shapes[0];
         if(count($shapes)>1){
-            foreach($shapes as &$shape)
+            foreach($shapes as &$shape) {
                 $shape = $this->defApplyMatrix($shape, $matrix);
+            }
             return implode(' ', $shapes);
         }
 
@@ -466,7 +477,7 @@ class EasySVG {
         $return = '';
         foreach($instructions as &$instruction){
             $i = preg_replace('/[^a-zA-Z]*/', '', $instruction);
-            preg_match_all('/\-?[0-9\.]+/', $instruction, $coords);
+            preg_match_all('/-?[0-9.]+/', $instruction, $coords);
             $coords = $coords[0];
 
             if(empty($coords)){
@@ -477,7 +488,7 @@ class EasySVG {
             while(count($coords)>0){
 
                 // do the matrix calculation stuff
-                list($a, $b, $c, $d, $e, $f) = $matrix;
+                [$a, $b, $c, $d, $e, $f] = $matrix;
 
                 // exception for relative instruction
                 if( preg_match('/[a-z]/', $i) ){
@@ -486,9 +497,9 @@ class EasySVG {
                 }
 
                 // convert horizontal lineto (relative)
-                if( $i=='h' ){
+                if( $i === 'h' ){
                     $i = 'l';
-                    $x = floatval( array_shift($coords) );
+                    $x = (float)array_shift($coords);
                     $y = 0;
 
                     // add new point's coordinates
@@ -500,10 +511,10 @@ class EasySVG {
                 }
 
                 // convert vertical lineto (relative)
-                elseif( $i=='v' ){
+                elseif( $i === 'v' ){
                     $i = 'l';
                     $x = 0;
-                    $y = floatval( array_shift($coords) );
+                    $y = (float)array_shift($coords);
 
                     // add new point's coordinates
                     $current_point = array(
@@ -514,9 +525,9 @@ class EasySVG {
                 }
 
                 // convert quadratic bezier curve (relative)
-                elseif( $i=='q' ){
-                    $x = floatval( array_shift($coords) );
-                    $y = floatval( array_shift($coords) );
+                elseif( $i === 'q' ){
+                    $x = (float)array_shift($coords);
+                    $y = (float)array_shift($coords);
 
                     // add new point's coordinates
                     $current_point = array(
@@ -526,8 +537,8 @@ class EasySVG {
                     $new_coords = array_merge($new_coords, $current_point);
 
                     // same for 2nd point
-                    $x = floatval( array_shift($coords) );
-                    $y = floatval( array_shift($coords) );
+                    $x = (float)array_shift($coords);
+                    $y = (float)array_shift($coords);
 
                     // add new point's coordinates
                     $current_point = array(
@@ -541,8 +552,8 @@ class EasySVG {
                 // @TODO: handle 'a,c,s' (elliptic arc curve) commands
                 // cf. http://www.w3.org/TR/SVG/paths.html#PathDataCurveCommands
                 else{
-                    $x = floatval( array_shift($coords) );
-                    $y = floatval( array_shift($coords) );
+                    $x = (float)array_shift($coords);
+                    $y = (float)array_shift($coords);
 
                     // add new point's coordinates
                     $current_point = array(
@@ -558,7 +569,7 @@ class EasySVG {
             $instruction = $i . implode(',', $new_coords);
 
             // remove useless commas
-            $instruction = preg_replace('/,\-/','-', $instruction);
+            $instruction = preg_replace('/,-/','-', $instruction);
         }
 
         return implode('', $instructions);
@@ -577,7 +588,8 @@ class EasySVG {
      * Return full SVG XML
      * @return string
      */
-    public function asXML(){
+    public function asXML(): string
+    {
         return $this->svg->asXML();
     }
 
@@ -586,7 +598,8 @@ class EasySVG {
      * @param string $key
      * @param string $value
      */
-    public function addAttribute($key, $value){
-        return $this->svg->addAttribute($key, $value);
+    public function addAttribute(string $key, string $value): void
+    {
+        $this->svg->addAttribute($key, $value);
     }
 }

--- a/src/EasySVG.php
+++ b/src/EasySVG.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * EasySVG - Generate SVG from PHP
  * @author Simon Tarchichi <kartsims@gmail.com>
@@ -8,21 +11,22 @@
  * @see http://stackoverflow.com/questions/14684846/flattening-svg-matrix-transforms-in-inkscape
  * @see http://stackoverflow.com/questions/7742148/how-to-convert-text-to-svg-paths
  */
-class EasySVG {
-
+class EasySVG
+{
     protected stdClass $font;
     protected SimpleXMLElement $svg;
 
-    public function __construct() {
+    public function __construct()
+    {
         // default font data
-        $this->font = new stdClass;
+        $this->font = new stdClass();
         $this->font->id = '';
         $this->font->horizAdvX = 0;
         $this->font->unitsPerEm = 0;
         $this->font->ascent = 0;
         $this->font->descent = 0;
-        $this->font->glyphs = array();
-        $this->font->hkern = array();
+        $this->font->glyphs = [];
+        $this->font->hkern = [];
         $this->font->useKerning = false;
         $this->font->size = 20;
         $this->font->color = null;
@@ -44,25 +48,25 @@ class EasySVG {
      * @param string $str
      * @return array
      */
-    private function _utf8ToUnicode( string $str ): array
+    private function _utf8ToUnicode(string $str): array
     {
         $unicode = [];
         $values = [];
         $lookingFor = 1;
 
-        for ($i = 0, $iMax = strlen($str); $i < $iMax; $i++ ) {
-            $thisValue = ord( $str[ $i ] );
-            if ( $thisValue < 128 ) {
+        for ($i = 0, $iMax = strlen($str); $i < $iMax; $i++) {
+            $thisValue = ord($str[ $i ]);
+            if ($thisValue < 128) {
                 $unicode[] = $thisValue;
             } else {
-                if ( count( $values ) === 0 ) {
+                if (count($values) === 0) {
                     $lookingFor = ($thisValue < 224) ? 2 : 3;
                 }
                 $values[] = $thisValue;
-                if ( count( $values ) === $lookingFor ) {
-                    $number = ( $lookingFor === 3 ) ?
-                        ( ( $values[0] % 16 ) * 4096 ) + ( ( $values[1] % 64 ) * 64 ) + ( $values[2] % 64 ):
-                        ( ( $values[0] % 32 ) * 64 ) + ( $values[1] % 64 );
+                if (count($values) === $lookingFor) {
+                    $number = ($lookingFor === 3) ?
+                        (($values[0] % 16) * 4096) + (($values[1] % 64) * 64) + ($values[2] % 64) :
+                        (($values[0] % 32) * 64) + ($values[1] % 64);
 
                     $unicode[] = $number;
                     $values = [];
@@ -80,7 +84,7 @@ class EasySVG {
      * @param integer $size
      * @param string|null $color
      */
-    public function setFont( string $filepath, int $size, string $color = null ): void
+    public function setFont(string $filepath, int $size, string $color = null): void
     {
         $this->setFontSVG($filepath);
         $this->setFontSize($size);
@@ -94,7 +98,7 @@ class EasySVG {
      * @param int $size
      * @return void
      */
-    public function setFontSize( int $size ): void
+    public function setFontSize(int $size): void
     {
         $this->font->size = $size;
     }
@@ -104,7 +108,7 @@ class EasySVG {
      * @param bool $bool
      * @return void
      */
-    public function setUseKerning( bool $bool ): void
+    public function setUseKerning(bool $bool): void
     {
         $this->font->useKerning = $bool;
     }
@@ -114,7 +118,7 @@ class EasySVG {
      * @param string $color
      * @return void
      */
-    public function setFontColor( string $color ): void
+    public function setFontColor(string $color): void
     {
         $this->font->color = $color;
     }
@@ -124,7 +128,7 @@ class EasySVG {
      * @param float $value
      * @return void
      */
-    public function setLineHeight( float $value ): void
+    public function setLineHeight(float $value): void
     {
         $this->font->lineHeight = $value;
     }
@@ -134,7 +138,7 @@ class EasySVG {
      * @param float $value
      * @return void
      */
-    public function setLetterSpacing( float $value ): void
+    public function setLetterSpacing(float $value): void
     {
         $this->font->letterSpacing = $value;
     }
@@ -146,10 +150,10 @@ class EasySVG {
      * @param string $filepath
      * @return void
      */
-    public function setFontSVG( string $filepath ): void
+    public function setFontSVG(string $filepath): void
     {
         $this->font->glyphs = [];
-        $z = new XMLReader;
+        $z = new XMLReader();
         $z->open($filepath);
 
         // move to the first <product /> node
@@ -207,14 +211,14 @@ class EasySVG {
      * @param array $attributes
      * @return null|SimpleXMLElement
      */
-    public function addPath(string $def, array $attributes=array()): ?SimpleXMLElement
+    public function addPath(string $def, array $attributes=[]): ?SimpleXMLElement
     {
         $path = $this->svg->addChild('path');
         if ($path === null) {
             return null;
         }
 
-        foreach($attributes as $key => $value) {
+        foreach ($attributes as $key => $value) {
             $path->addAttribute($key, $value);
         }
 
@@ -231,7 +235,7 @@ class EasySVG {
      * @param array $attributes
      * @return null|SimpleXMLElement
      */
-    public function addText(string $text, $x = 0, $y = 0, array $attributes=array()): ?SimpleXMLElement
+    public function addText(string $text, $x = 0, $y = 0, array $attributes=[]): ?SimpleXMLElement
     {
         $def = $this->textDef($text);
 
@@ -241,7 +245,7 @@ class EasySVG {
 
         // center horizontally
         if ($x === 'center') {
-            if ($this->svg['width'] === NULL) {
+            if ($this->svg['width'] === null) {
                 throw new Error('SVG width has to be set to center the text horizontally');
             }
             $x = ((int)$this->svg['width'] - $textWidth) / 2;
@@ -249,17 +253,17 @@ class EasySVG {
 
         // center vertically
         if ($y === 'center') {
-            if ($this->svg['height'] === NULL) {
+            if ($this->svg['height'] === null) {
                 throw new Error('SVG height has to be set to center the text vertically');
             }
             $y = ((int)$this->svg['height'] - $textHeight) / 2;
         }
 
-        if($x !== 0 || $y !== 0){
+        if ($x !== 0 || $y !== 0) {
             $def = $this->defTranslate($def, $x, $y);
         }
 
-        if($this->font->color) {
+        if ($this->font->color) {
             $attributes['fill'] = $this->font->color;
         }
 
@@ -273,7 +277,7 @@ class EasySVG {
      */
     public function textDef(string $text): string
     {
-        $def = array();
+        $def = [];
 
         $horizAdvX = 0;
         $horizAdvY = $this->font->ascent + $this->font->descent;
@@ -284,19 +288,19 @@ class EasySVG {
 
         foreach ($textUnicode as $letter) {
             // kern
-            if ($this->font->useKerning && isset ($this->font->hkern[$prevLetter][$letter])) {
+            if ($this->font->useKerning && isset($this->font->hkern[$prevLetter][$letter])) {
                 $horizAdvX -= $this->font->hkern[$prevLetter][$letter] * $fontSize;
             }
 
             //ignore this glyph instead of throwing an error if the font does not define it
-            if(!array_key_exists($letter, $this->font->glyphs)){
+            if (!array_key_exists($letter, $this->font->glyphs)) {
                 continue;
             }
 
             // line break support (10 is unicode for linebreak)
-            if($letter === 10){
+            if ($letter === 10) {
                 $horizAdvX = 0;
-                $horizAdvY += $this->font->lineHeight * ( $this->font->ascent + $this->font->descent );
+                $horizAdvY += $this->font->lineHeight * ($this->font->ascent + $this->font->descent);
                 continue;
             }
 
@@ -329,7 +333,7 @@ class EasySVG {
         $textUnicode = $this->_utf8ToUnicode($text);
 
         $lineWidth = 0;
-        $lineHeight = ( $this->font->ascent + $this->font->descent ) * $fontSize * 2;
+        $lineHeight = ($this->font->ascent + $this->font->descent) * $fontSize * 2;
 
         $width = 0;
         $height = $lineHeight;
@@ -338,12 +342,12 @@ class EasySVG {
 
         foreach ($textUnicode as $letter) {
             //ignore this glyph instead of throwing an error if the font does not define it
-            if(!array_key_exists($letter, $this->font->glyphs)){
+            if (!array_key_exists($letter, $this->font->glyphs)) {
                 continue;
             }
 
             // line break support (10 is unicode for linebreak)
-            if($letter === 10){
+            if ($letter === 10) {
                 $width = max($lineWidth, $width);
                 $height += $lineHeight * $this->font->lineHeight;
                 $lineWidth = 0;
@@ -353,7 +357,7 @@ class EasySVG {
             $lineWidth += $this->font->glyphs[$letter]->horizAdvX * $fontSize + $this->font->em * $this->font->letterSpacing * $fontSize;
 
             // kern
-            if ($this->font->useKerning && isset ($this->font->hkern[$prevLetter][$letter])) {
+            if ($this->font->useKerning && isset($this->font->hkern[$prevLetter][$letter])) {
                 $lineWidth -= $this->font->hkern[$prevLetter][$letter] * $fontSize;
             }
 
@@ -363,7 +367,7 @@ class EasySVG {
         // only keep the widest line's width
         $width = max($lineWidth, $width);
 
-        return array($width, $height);
+        return [$width, $height];
     }
 
 
@@ -372,9 +376,8 @@ class EasySVG {
      * @param string $unicode
      * @return string
      */
-    public function unicodeDef( string $unicode ): string
+    public function unicodeDef(string $unicode): string
     {
-
         $horizAdvY = $this->font->ascent + $this->font->descent;
         $fontSize =  (float)$this->font->size / $this->font->unitsPerEm;
 
@@ -392,16 +395,17 @@ class EasySVG {
      * @param boolean $is_unicode
      * @return float
      */
-    public function characterWidth( string $char, bool $is_unicode = false ) {
-        if ($is_unicode){
+    public function characterWidth(string $char, bool $is_unicode = false)
+    {
+        if ($is_unicode) {
             $letter = hexdec($char);
-        }
-        else {
+        } else {
             $letter = $this->_utf8ToUnicode($char);
         }
 
-        if (!isset($this->font->glyphs[$letter]))
-            return NULL;
+        if (!isset($this->font->glyphs[$letter])) {
+            return null;
+        }
 
         $fontSize = (float)$this->font->size / $this->font->unitsPerEm;
         return $this->font->glyphs[$letter]->horizAdvX * $fontSize;
@@ -417,7 +421,7 @@ class EasySVG {
      */
     public function defTranslate(string $def, float $x = 0, float $y = 0): string
     {
-        return $this->defApplyMatrix($def, array(1, 0, 0, 1, $x, $y));
+        return $this->defApplyMatrix($def, [1, 0, 0, 1, $x, $y]);
     }
 
     /**
@@ -430,7 +434,7 @@ class EasySVG {
      */
     public function defRotate(string $def, float $angle, float $x = 0, float $y = 0): string
     {
-        if($x === 0 && $y === 0){
+        if ($x === 0 && $y === 0) {
             $angle = deg2rad($angle);
             return $this->defApplyMatrix($def, [cos($angle), sin($angle), -sin($angle), cos($angle), 0, 0]);
         }
@@ -464,8 +468,8 @@ class EasySVG {
         // if there are several shapes in this definition, do the operation for each
         preg_match_all('/M[^zZ]*[zZ]/', $def, $shapes);
         $shapes = $shapes[0];
-        if(count($shapes)>1){
-            foreach($shapes as &$shape) {
+        if (count($shapes)>1) {
+            foreach ($shapes as &$shape) {
                 $shape = $this->defApplyMatrix($shape, $matrix);
             }
             return implode(' ', $shapes);
@@ -475,65 +479,65 @@ class EasySVG {
         $instructions = $instructions[0];
 
         $return = '';
-        foreach($instructions as &$instruction){
+        foreach ($instructions as &$instruction) {
             $i = preg_replace('/[^a-zA-Z]*/', '', $instruction);
             preg_match_all('/-?[0-9.]+/', $instruction, $coords);
             $coords = $coords[0];
 
-            if(empty($coords)){
+            if (empty($coords)) {
                 continue;
             }
 
-            $new_coords = array();
-            while(count($coords)>0){
+            $new_coords = [];
+            while (count($coords)>0) {
 
                 // do the matrix calculation stuff
                 [$a, $b, $c, $d, $e, $f] = $matrix;
 
                 // exception for relative instruction
-                if( preg_match('/[a-z]/', $i) ){
+                if (preg_match('/[a-z]/', $i)) {
                     $e = 0;
                     $f = 0;
                 }
 
                 // convert horizontal lineto (relative)
-                if( $i === 'h' ){
+                if ($i === 'h') {
                     $i = 'l';
                     $x = (float)array_shift($coords);
                     $y = 0;
 
                     // add new point's coordinates
-                    $current_point = array(
+                    $current_point = [
                         $a*$x + $c*$y + $e,
                         $b*$x + $d*$y + $f,
-                    );
+                    ];
                     $new_coords = array_merge($new_coords, $current_point);
                 }
 
                 // convert vertical lineto (relative)
-                elseif( $i === 'v' ){
+                elseif ($i === 'v') {
                     $i = 'l';
                     $x = 0;
                     $y = (float)array_shift($coords);
 
                     // add new point's coordinates
-                    $current_point = array(
+                    $current_point = [
                         $a*$x + $c*$y + $e,
                         $b*$x + $d*$y + $f,
-                    );
+                    ];
                     $new_coords = array_merge($new_coords, $current_point);
                 }
 
                 // convert quadratic bezier curve (relative)
-                elseif( $i === 'q' ){
+                elseif ($i === 'q') {
                     $x = (float)array_shift($coords);
                     $y = (float)array_shift($coords);
 
                     // add new point's coordinates
-                    $current_point = array(
+                    $current_point = [
                         $a*$x + $c*$y + $e,
                         $b*$x + $d*$y + $f,
-                    );
+                    ];
                     $new_coords = array_merge($new_coords, $current_point);
 
                     // same for 2nd point
@@ -541,35 +545,33 @@ class EasySVG {
                     $y = (float)array_shift($coords);
 
                     // add new point's coordinates
-                    $current_point = array(
+                    $current_point = [
                         $a*$x + $c*$y + $e,
                         $b*$x + $d*$y + $f,
-                    );
+                    ];
                     $new_coords = array_merge($new_coords, $current_point);
                 }
 
                 // every other commands
                 // @TODO: handle 'a,c,s' (elliptic arc curve) commands
                 // cf. http://www.w3.org/TR/SVG/paths.html#PathDataCurveCommands
-                else{
+                else {
                     $x = (float)array_shift($coords);
                     $y = (float)array_shift($coords);
 
                     // add new point's coordinates
-                    $current_point = array(
+                    $current_point = [
                         $a*$x + $c*$y + $e,
                         $b*$x + $d*$y + $f,
-                    );
+                    ];
                     $new_coords = array_merge($new_coords, $current_point);
                 }
-
-
             }
 
             $instruction = $i . implode(',', $new_coords);
 
             // remove useless commas
-            $instruction = preg_replace('/,-/','-', $instruction);
+            $instruction = preg_replace('/,-/', '-', $instruction);
         }
 
         return implode('', $instructions);

--- a/src/EasySVG.php
+++ b/src/EasySVG.php
@@ -45,11 +45,15 @@ class EasySVG
 
     /**
      * Function takes UTF-8 encoded string and returns unicode number for every character.
-     * @param string $str
+     * @param null|string $str
      * @return array
      */
-    private function _utf8ToUnicode(string $str): array
+    private function _utf8ToUnicode(?string $str): array
     {
+        if ($str === null) {
+            return [];
+        }
+
         $unicode = [];
         $values = [];
         $lookingFor = 1;
@@ -174,21 +178,24 @@ class EasySVG
 
                 if ($name === 'glyph') {
                     $unicode = $z->getAttribute('unicode');
-                    $unicode = $this->_utf8ToUnicode($unicode);
 
-                    if (isset($unicode[0])) {
-                        $unicode = $unicode[0];
+                    if (isset($unicode)) {
+                        $unicode = $this->_utf8ToUnicode($unicode);
 
-                        $this->font->glyphs[$unicode] = new stdClass();
-                        $this->font->glyphs[$unicode]->horizAdvX = $z->getAttribute('horiz-adv-x');
-                        if (empty($this->font->glyphs[$unicode]->horizAdvX)) {
-                            $this->font->glyphs[$unicode]->horizAdvX = $this->font->horizAdvX;
-                        }
-                        $this->font->glyphs[$unicode]->d = $z->getAttribute('d');
+                        if (isset($unicode[0])) {
+                            $unicode = $unicode[0];
 
-                        // save em value for letter spacing (109 is unicode for the letter 'm')
-                        if ($unicode === '109') {
-                            $this->font->em = $this->font->glyphs[$unicode]->horizAdvX;
+                            $this->font->glyphs[$unicode] = new stdClass();
+                            $this->font->glyphs[$unicode]->horizAdvX = $z->getAttribute('horiz-adv-x');
+                            if (empty($this->font->glyphs[$unicode]->horizAdvX)) {
+                                $this->font->glyphs[$unicode]->horizAdvX = $this->font->horizAdvX;
+                            }
+                            $this->font->glyphs[$unicode]->d = $z->getAttribute('d');
+
+                            // save em value for letter spacing (109 is unicode for the letter 'm')
+                            if ($unicode === '109') {
+                                $this->font->em = $this->font->glyphs[$unicode]->horizAdvX;
+                            }
                         }
                     }
                 }

--- a/src/EasySVG.php
+++ b/src/EasySVG.php
@@ -193,7 +193,7 @@ class EasySVG
                             $this->font->glyphs[$unicode]->d = $z->getAttribute('d');
 
                             // save em value for letter spacing (109 is unicode for the letter 'm')
-                            if ($unicode === '109') {
+                            if ($unicode === 109) {
                                 $this->font->em = $this->font->glyphs[$unicode]->horizAdvX;
                             }
                         }


### PR DESCRIPTION
Great lib!

In this PR, I added a lot of type-hints and updated the minimum PHP version to 7.4.
I also removed all deprecated usages of old PHP versions and implemented some best-practices. Most changes are return type-hints, parameter type-hints and casts.

One heads up: the `addPath` method can now return `null`. In previous versions it would have thrown an exception, since it tried to call a method on `null`.

Let me know what you think! If these changes are too much at once, I am happy to re-submit finer-grained PRs.