### PR TITLE
Handle if glyph has no d attribute, fix issue #33

### DIFF
--- a/src/EasySVG.php
+++ b/src/EasySVG.php
@@ -390,6 +390,10 @@ class EasySVG
 
         // extract character definition
         $d = $this->font->glyphs[hexdec($unicode)]->d;
+        // handle if d attribute is not set in corresponding glyph
+        if(is_null($d)) {
+            $d = "";
+        }
 
         // transform typo from original SVG format to straight display
         $d = $this->defScale($d, $fontSize, -$fontSize);


### PR DESCRIPTION
This fixes php getting into fatal error if the glyph does not exist or if the glyph has the d attribute not set like it happens with the space glyph when exporting from FontForge as it omits empty attributes in the output