### PR TITLE
Resize svg to fit path

### DIFF
--- a/demo/index.php
+++ b/demo/index.php
@@ -27,10 +27,8 @@ require '../src/EasySVG.php';
             $svg->addText($text);
             // set width/height according to text
 
-            $file = tmpfile();
-            fwrite($file, $svg->asXML());
-            $output = shell_exec('inkscape --export-type=svg -o - --export-area-drawing ' . stream_get_meta_data($file)['uri']);
-            echo $output;
+            $svg->setInkScapePath('inkscape');
+            echo $svg->getResizedXML();
             ?>
             <br/><br/><br/>
             <h2>PHP code</h2>
@@ -47,10 +45,8 @@ require '../src/EasySVG.php';
                 $svg->addText($text);
                 // set width/height according to text
 
-                $file = tmpfile();
-                fwrite($file, $svg->asXML());
-                $output = shell_exec('inkscape --export-type=svg -o - --export-area-drawing ' . stream_get_meta_data($file)['uri']);
-                echo $output;
+                $svg->setInkScapePath('inkscape');
+                echo $svg->getResizedXML();
             </pre>
             <br/><br/><br/>
 
@@ -68,10 +64,8 @@ require '../src/EasySVG.php';
             $svg->setLetterSpacing(.1);
             $svg->setUseKerning(true);
             $svg->addText($text, "center", "center");
-            $file = tmpfile();
-            fwrite($file, $svg->asXML());
-            $output = shell_exec('inkscape --export-type=svg -o - --export-area-drawing ' . stream_get_meta_data($file)['uri']);
-            echo $output;
+            $svg->setInkScapePath('inkscape');
+            echo $svg->getResizedXML();
             ?>
             <br/><br/><br/>
             <h2>PHP code</h2>
@@ -88,10 +82,8 @@ require '../src/EasySVG.php';
                 $svg->setLetterSpacing(.1);
                 $svg->setUseKerning(true);
                 $svg->addText($text, "center", "center");
-                $file = tmpfile();
-                fwrite($file, $svg->asXML());
-                $output = shell_exec('inkscape --export-type=svg -o - --export-area-drawing ' . stream_get_meta_data($file)['uri']);
-                echo $output;
+                $svg->setInkScapePath('inkscape');
+                echo $svg->getResizedXML();
             </pre>
             <br/><br/><br/>
         </div>

--- a/demo/index.php
+++ b/demo/index.php
@@ -26,10 +26,11 @@ require '../src/EasySVG.php';
             $svg->setUseKerning(true);
             $svg->addText($text);
             // set width/height according to text
-            list($textWidth, $textHeight) = $svg->textDimensions($text);
-            $svg->addAttribute("width", $textWidth."px");
-            $svg->addAttribute("height", $textHeight."px");
-            echo $svg->asXML();
+
+            $file = tmpfile();
+            fwrite($file, $svg->asXML());
+            $output = shell_exec('inkscape --export-type=svg -o - --export-area-drawing ' . stream_get_meta_data($file)['uri']);
+            echo $output;
             ?>
             <br/><br/><br/>
             <h2>PHP code</h2>
@@ -45,10 +46,11 @@ require '../src/EasySVG.php';
                 $svg->setUseKerning(true);
                 $svg->addText($text);
                 // set width/height according to text
-                list($textWidth, $textHeight) = $svg->textDimensions($text);
-                $svg->addAttribute("width", $textWidth."px");
-                $svg->addAttribute("height", $textHeight."px");
-                echo $svg->asXML();
+
+                $file = tmpfile();
+                fwrite($file, $svg->asXML());
+                $output = shell_exec('inkscape --export-type=svg -o - --export-area-drawing ' . stream_get_meta_data($file)['uri']);
+                echo $output;
             </pre>
             <br/><br/><br/>
 
@@ -66,12 +68,15 @@ require '../src/EasySVG.php';
             $svg->setLetterSpacing(.1);
             $svg->setUseKerning(true);
             $svg->addText($text, "center", "center");
-            echo $svg->asXML();
+            $file = tmpfile();
+            fwrite($file, $svg->asXML());
+            $output = shell_exec('inkscape --export-type=svg -o - --export-area-drawing ' . stream_get_meta_data($file)['uri']);
+            echo $output;
             ?>
             <br/><br/><br/>
             <h2>PHP code</h2>
             <pre>
-                $text = "Simple text display\netc.";
+                $text = "Simple text";
 
                 $svg = new EasySVG();
                 $svg->addAttribute("width", "600px");
@@ -83,7 +88,10 @@ require '../src/EasySVG.php';
                 $svg->setLetterSpacing(.1);
                 $svg->setUseKerning(true);
                 $svg->addText($text, "center", "center");
-                echo $svg->asXML();
+                $file = tmpfile();
+                fwrite($file, $svg->asXML());
+                $output = shell_exec('inkscape --export-type=svg -o - --export-area-drawing ' . stream_get_meta_data($file)['uri']);
+                echo $output;
             </pre>
             <br/><br/><br/>
         </div>

--- a/src/EasySVG.php
+++ b/src/EasySVG.php
@@ -15,6 +15,7 @@ class EasySVG
 {
     protected stdClass $font;
     protected SimpleXMLElement $svg;
+    private $inkScapePath;
 
     public function __construct()
     {
@@ -611,5 +612,32 @@ class EasySVG
     public function addAttribute(string $key, string $value): void
     {
         $this->svg->addAttribute($key, $value);
+    }
+
+    /**
+     * Sets the path to the InkScape command so it can be used
+     * to resize the SVG output
+     * @param string $inkScapePath
+     */
+    public function setInkScapePath(string $inkScapePath): void
+    {
+        $this->inkScapePath = $inkScapePath;
+    }
+
+
+    /**
+     * Return full SVG XML exported from InkScape
+     * @return string
+     */
+    public function getResizedXML(): string
+    {
+        if($this->inkScapePath){
+            $file = tmpfile();
+            fwrite($file, $this->asXML());
+            $output = shell_exec($this->inkScapePath . ' --export-type=svg -o - --export-area-drawing ' . stream_get_meta_data($file)['uri']);
+            return $output;
+        } else{
+            throw new Exception('inkScapePath not set');
+        }
     }
 }

--- a/src/EasySVG.php
+++ b/src/EasySVG.php
@@ -313,6 +313,7 @@ class EasySVG
 
             // extract character definition
             $d = $this->font->glyphs[$letter]->d;
+            $d = $d?$d:'';
 
             // transform typo from original SVG format to straight display
             $d = $this->defScale($d, $fontSize, -$fontSize);


### PR DESCRIPTION
Added resizing of the SVG output using InkScape. The path of InkScape has to be set for this feature to be used.

Closes #35.