### PR TITLE
fix: string must be nullable

### DIFF
--- a/src/EasySVG.php
+++ b/src/EasySVG.php
@@ -88,7 +88,7 @@ class EasySVG
      * @param integer $size
      * @param string|null $color
      */
-    public function setFont(string $filepath, int $size, string $color = null): void
+    public function setFont(string $filepath, int $size, ?string $color = null): void
     {
         $this->setFontSVG($filepath);
         $this->setFontSize($size);


### PR DESCRIPTION
I updated the signature of `setFont` with a nullable string because of the default `null` value.

Plus, not making the string nullable with a default `null` value is deprecated in PHP 8.4.